### PR TITLE
feat: use absolute paths on imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "[typescript]": {
+    "typescript.preferences.importModuleSpecifier": "non-relative"
+  }
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,5 @@
+import { bootstrap } from '@container.js';
 import express, { type Application } from 'express';
-import { bootstrap } from './container.js';
 
 export function initApp(): Application {
   const app = express();

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,5 +1,5 @@
-import { PolygonIndexerService } from 'application/services/polygon-indexer.service.js';
-import { PolygonScheduler } from 'infrastructure/jobs/polygon.scheduler.js';
+import { PolygonIndexerService } from '@application/services/polygon-indexer.service.js';
+import { PolygonScheduler } from '@infrastructure/jobs/polygon.scheduler.js';
 
 export function bootstrap() {
   const polygonIndexer = new PolygonIndexerService();

--- a/src/domain/repositories/events.repository.ts
+++ b/src/domain/repositories/events.repository.ts
@@ -1,4 +1,4 @@
-import type { ParsedFeeCollectorEvent } from '../entities/parsed-fee-collector-event.entity.js';
+import type { ParsedFeeCollectorEvent } from '@domain/entities/parsed-fee-collector-event.entity.js';
 
 export interface EventsRepository {
   storeFeeCollectorEvent(event: ParsedFeeCollectorEvent): Promise<void>;

--- a/src/domain/repositories/evm.client.ts
+++ b/src/domain/repositories/evm.client.ts
@@ -1,4 +1,4 @@
-import type { ParsedFeeCollectorEvent } from '../entities/parsed-fee-collector-event.entity.js';
+import type { ParsedFeeCollectorEvent } from '@domain/entities/parsed-fee-collector-event.entity.js';
 
 type BlockTag = string | number;
 

--- a/src/infrastructure/evm/polygon-evm.client.ts
+++ b/src/infrastructure/evm/polygon-evm.client.ts
@@ -1,6 +1,6 @@
 import { type BlockTag } from '@ethersproject/abstract-provider';
-import type { ParsedFeeCollectorEvent } from 'domain/entities/parsed-fee-collector-event.entity.js';
-import type { EVMClient } from 'domain/repositories/evm.client.js';
+import type { ParsedFeeCollectorEvent } from '@domain/entities/parsed-fee-collector-event.entity.js';
+import type { EVMClient } from '@domain/repositories/evm.client.js';
 import { BigNumber, ethers } from 'ethers';
 import { FeeCollector__factory } from 'lifi-contract-typings';
 

--- a/src/infrastructure/jobs/polygon.scheduler.ts
+++ b/src/infrastructure/jobs/polygon.scheduler.ts
@@ -1,4 +1,4 @@
-import { PolygonIndexerService } from 'application/services/polygon-indexer.service.js';
+import type { PolygonIndexerService } from '@application/services/polygon-indexer.service.js';
 
 export class PolygonScheduler {
   constructor(private polygonIndexerService: PolygonIndexerService) {}

--- a/src/infrastructure/persistence/mongo-events.repository.ts
+++ b/src/infrastructure/persistence/mongo-events.repository.ts
@@ -1,5 +1,5 @@
-import type { ParsedFeeCollectorEvent } from 'domain/entities/parsed-fee-collector-event.entity.js';
-import type { EventsRepository } from 'domain/repositories/events.repository.js';
+import type { ParsedFeeCollectorEvent } from '@domain/entities/parsed-fee-collector-event.entity.js';
+import type { EventsRepository } from '@domain/repositories/events.repository.js';
 
 export class MongoEventsRepository implements EventsRepository {
   async storeFeeCollectorEvent(event: ParsedFeeCollectorEvent): Promise<void> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
+import { initApp } from '@app.js';
 import 'dotenv/config';
-import { initApp } from './app.js';
 
 const app = initApp();
 const port = process.env.PORT ?? 3000;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
     "module": "NodeNext",
     "moduleResolution": "Node16",
     "outDir": "dist",
+    "paths": {
+      "@*": ["*"]
+    },
     "rootDir": "src",
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
This pull request standardizes import paths throughout the codebase by switching to absolute imports using path aliases (e.g., `@domain`, `@application`) rather than relative paths. Additionally, it updates TypeScript preferences in the VSCode settings to favor non-relative import module specifiers, ensuring consistency for future development.

**Import Path Refactoring:**

* Changed all relative imports to use absolute path aliases (such as `@domain`, `@application`, and `@infrastructure`) across multiple files.

**Editor Configuration:**

* Added a VSCode settings file to enforce the use of non-relative TypeScript import module specifiers for the project. (.vscode/settings.json)