### PR TITLE
feat: retrieve events from blockchain

### DIFF
--- a/src/application/services/polygon-indexer.service.ts
+++ b/src/application/services/polygon-indexer.service.ts
@@ -16,4 +16,8 @@ export class PolygonIndexerService {
     logger.info(`Fetched ${res.length} FeesCollected events`);
     logger.info(res); // TODO: remove events logging
   }
+
+  async getLastBlockNumber(): Promise<number> {
+    return this.polygonClient.getLastBlockNumber();
+  }
 }

--- a/src/application/services/polygon-indexer.service.ts
+++ b/src/application/services/polygon-indexer.service.ts
@@ -1,8 +1,19 @@
+import type { EVMClient } from '@domain/repositories/evm.client.js';
 import { logger } from '@infrastructure/logging/logger.js';
 
 export class PolygonIndexerService {
-  async index(fromBlock: number, toBlock: number): Promise<void> {
-    // TODO: Implementation for indexing the fee collector events
+  constructor(private polygonClient: EVMClient) {}
+
+  async indexFeeCollectionEvents(
+    fromBlock: number,
+    toBlock: number,
+  ): Promise<void> {
     logger.info(`Indexing from block ${fromBlock} to block ${toBlock}`);
+    const res = await this.polygonClient.fetchFeeCollectorEvents(
+      fromBlock,
+      toBlock,
+    );
+    logger.info(`Fetched ${res.length} FeesCollected events`);
+    logger.info(res); // TODO: remove events logging
   }
 }

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,8 +1,10 @@
 import { PolygonIndexerService } from '@application/services/polygon-indexer.service.js';
+import { PolygonEVMClient } from '@infrastructure/evm/polygon-evm.client.js';
 import { PolygonScheduler } from '@infrastructure/jobs/polygon.scheduler.js';
 
 export function bootstrap() {
-  const polygonIndexer = new PolygonIndexerService();
+  const polygonClient = new PolygonEVMClient();
+  const polygonIndexer = new PolygonIndexerService(polygonClient);
   const polygonScheduler = new PolygonScheduler(polygonIndexer);
   polygonScheduler.start();
   return { polygonScheduler };

--- a/src/domain/repositories/evm.client.ts
+++ b/src/domain/repositories/evm.client.ts
@@ -7,4 +7,6 @@ export interface EVMClient {
     fromBlock: BlockTag,
     toBlock: BlockTag,
   ): Promise<ParsedFeeCollectorEvent[]>;
+
+  getLastBlockNumber(): Promise<number>;
 }

--- a/src/infrastructure/evm/polygon-evm.client.ts
+++ b/src/infrastructure/evm/polygon-evm.client.ts
@@ -9,6 +9,13 @@ export class PolygonEVMClient implements EVMClient {
   private static CONTRACT_ADDRESS =
     '0xbD6C7B0d2f68c2b7805d88388319cfB6EcB50eA9';
   private static POLYGON_RPC = 'https://polygon-rpc.com';
+  private provider: ethers.providers.JsonRpcProvider;
+
+  constructor() {
+    this.provider = new ethers.providers.JsonRpcProvider(
+      PolygonEVMClient.POLYGON_RPC,
+    );
+  }
 
   async fetchFeeCollectorEvents(
     fromBlock: BlockTag,
@@ -17,7 +24,7 @@ export class PolygonEVMClient implements EVMClient {
     const feeCollector = new ethers.Contract(
       PolygonEVMClient.CONTRACT_ADDRESS,
       FeeCollector__factory.createInterface(),
-      new ethers.providers.JsonRpcProvider(PolygonEVMClient.POLYGON_RPC),
+      this.provider,
     );
     const filter = feeCollector.filters.FeesCollected();
     const events = await feeCollector.queryFilter(filter, fromBlock, toBlock);
@@ -30,5 +37,13 @@ export class PolygonEVMClient implements EVMClient {
         lifiFee: BigNumber.from(parsedEvent.args[3]),
       };
     });
+  }
+
+  async getLastBlockNumber(): Promise<number> {
+    const block = await this.provider.getBlock('latest');
+    if (!block) {
+      throw new Error('Failed to fetch the latest block number');
+    }
+    return block.number;
   }
 }

--- a/src/infrastructure/jobs/polygon.scheduler.ts
+++ b/src/infrastructure/jobs/polygon.scheduler.ts
@@ -4,7 +4,8 @@ import { logger } from '@infrastructure/logging/logger.js';
 export class PolygonScheduler {
   private static BLOCK_DELTA = 50;
   private static INTERVAL_MS = 2_000;
-  private latestBlock: number = 70000000; // TODO: implement checkpoints.
+  private static INITIAL_BLOCK_NUMBER = 70000000;
+  private latestBlock: number = PolygonScheduler.INITIAL_BLOCK_NUMBER; // TODO: implement checkpoints.
 
   constructor(private polygonIndexerService: PolygonIndexerService) {}
 

--- a/src/infrastructure/jobs/polygon.scheduler.ts
+++ b/src/infrastructure/jobs/polygon.scheduler.ts
@@ -1,24 +1,32 @@
-import type { PolygonIndexerService } from '@application/services/polygon-indexer.service.js';
+import { PolygonIndexerService } from '@application/services/polygon-indexer.service.js';
 import { logger } from '@infrastructure/logging/logger.js';
 
 export class PolygonScheduler {
+  private static BLOCK_DELTA = 50;
+  private static INTERVAL_MS = 2_000;
+  private latestBlock: number = 70000000; // TODO: implement checkpoints.
+
   constructor(private polygonIndexerService: PolygonIndexerService) {}
 
-  start() {
-    const BLOCK_DELTA = 10;
-    const INTERVAL_MS = 5_000;
+  async start() {
+    await this._indexJob();
+    setInterval(() => this._indexJob(), PolygonScheduler.INTERVAL_MS);
+  }
 
-    setInterval(async () => {
-      const latestBlock = 70000000 + BLOCK_DELTA; // TODO: implement checkpoints.
-      const fromBlock = latestBlock - BLOCK_DELTA;
-      const toBlock = latestBlock;
-      try {
-        await this.polygonIndexerService.index(fromBlock, toBlock);
-      } catch (error) {
-        const err =
-          error instanceof Error ? error : new Error('Unexpected throw');
-        logger.error({ err, fromBlock, toBlock });
-      }
-    }, INTERVAL_MS);
+  private async _indexJob() {
+    const latestBlock = this.latestBlock + PolygonScheduler.BLOCK_DELTA; // TODO: implement checkpoints.
+    const fromBlock = latestBlock - PolygonScheduler.BLOCK_DELTA;
+    const toBlock = latestBlock;
+    try {
+      await this.polygonIndexerService.indexFeeCollectionEvents(
+        fromBlock,
+        toBlock,
+      );
+      this.latestBlock = latestBlock;
+    } catch (error) {
+      const err =
+        error instanceof Error ? error : new Error('Unexpected throw');
+      logger.error({ err, fromBlock, toBlock });
+    }
   }
 }


### PR DESCRIPTION
This pull request refactors the Polygon fee collection event indexing workflow to improve modularity and scheduling. The main changes include updating the service to use dependency injection for the Polygon client, renaming and implementing the fee collection event indexing method, and refactoring the scheduler for more robust and maintainable periodic indexing.

**Service and Dependency Injection Improvements:**

* Refactored `PolygonIndexerService` to accept an `EVMClient` via its constructor, enabling dependency injection and decoupling the service from direct client instantiation. (`src/application/services/polygon-indexer.service.ts`)
* Updated the application bootstrap to instantiate `PolygonEVMClient` and inject it into `PolygonIndexerService`. (`src/container.ts`)

**Fee Collection Event Indexing Implementation:**

* Renamed and implemented the indexing method as `indexFeeCollectionEvents`, which now fetches fee collector events from the Polygon client and logs the results. (`src/application/services/polygon-indexer.service.ts`)

**Scheduler Refactor and Improvements:**

* Refactored `PolygonScheduler` to use static configuration for block delta and interval, maintain internal state for the latest block, and run the indexing job at a fixed interval using the new method. (`src/infrastructure/jobs/polygon.scheduler.ts`)
* Improved error handling and logging within the scheduler job, and removed unnecessary type-only imports. (`src/infrastructure/jobs/polygon.scheduler.ts`)