### PR TITLE
feat: improve logging

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -42,7 +42,11 @@ async function _bootstrapChain(chainConfig: ChainConfig) {
     feesCollectedEventModel,
   );
   const evmClient = new EVMClient(chainConfig);
-  const evmIndexer = new EVMIndexerService(evmClient, mongoEventsRepository);
+  const evmIndexer = new EVMIndexerService(
+    chainConfig,
+    evmClient,
+    mongoEventsRepository,
+  );
   const evmScheduler = new EVMScheduler(evmIndexer, chainConfig);
   await evmScheduler.start();
 }

--- a/src/infrastructure/mongo/db.ts
+++ b/src/infrastructure/mongo/db.ts
@@ -18,7 +18,7 @@ export class db {
   private async connect(uri: string): Promise<void> {
     try {
       await mongoose.connect(uri);
-      logger.info(`MongoDB ready at ${uri}`);
+      logger.info('[Database] Successfully connected to MongoDB.');
     } catch (error) {
       logger.error(`MongoDB connection error: ${error}`);
       throw error; // This is a critical error, it should kill the process

--- a/src/infrastructure/mongo/mongo-events.repository.ts
+++ b/src/infrastructure/mongo/mongo-events.repository.ts
@@ -18,7 +18,6 @@ export class MongoEventsRepository implements EventsRepository {
     await this.feesCollectedEventModel.insertMany(
       events.map((e) => ParsedFeesCollectedEventMapper.toPersistence(e)),
     );
-    logger.info(`Stored ${events.length} feesCollected events`);
   }
 
   async setFeesCollectedLastBlock(blockNumber: number): Promise<void> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,5 +6,5 @@ const app = await initApp();
 const port = process.env.PORT ?? 3000;
 
 app.listen(port, () => {
-  logger.info(`Server is running on port ${port}`);
+  logger.info(`[HTTP Server] Listening at http://localhost:${port}`);
 });


### PR DESCRIPTION
This pull request introduces improvements to logging and service initialization for better traceability and clarity. The most significant change is the enhancement of log messages to include chain-specific context, which makes debugging and monitoring easier. Additionally, the initialization of the `EVMIndexerService` now requires the chain configuration, ensuring that the service has all necessary context for its operations.

**Logging improvements:**

* Enhanced log messages in `EVMIndexerService` to include the chain name, providing clearer context when indexing events and reporting the number of indexed events. (`src/application/services/evm-indexer.service.ts`, [[1]](diffhunk://#diff-cee7225b7463cf2343376e16617bf358b2b95dbf5ec872f1b51206278f3bdbf7R1-R22) [[2]](diffhunk://#diff-cee7225b7463cf2343376e16617bf358b2b95dbf5ec872f1b51206278f3bdbf7R33)
* Updated database connection log message to be more descriptive and standardized. (`src/infrastructure/mongo/db.ts`, [src/infrastructure/mongo/db.tsL21-R21](diffhunk://#diff-29cc4cab3cee62ec6df78bceea4421d940ec81bbfea5504e446372ec4bb01345L21-R21))
* Improved HTTP server startup log message for better clarity. (`src/server.ts`, [src/server.tsL9-R9](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595L9-R9))

**Service initialization and code cleanup:**

* Modified `EVMIndexerService` to accept `chainConfig` in its constructor, ensuring chain-specific context is available throughout the service. (`src/application/services/evm-indexer.service.ts`, [[1]](diffhunk://#diff-cee7225b7463cf2343376e16617bf358b2b95dbf5ec872f1b51206278f3bdbf7R1-R22); `src/container.ts`, [[2]](diffhunk://#diff-1d8d0990b05497c6fb57d06fa06c3637fd10e75e39ccc1cd61fbce13e4f2e6eeL45-R49)
* Removed redundant event storage log from `MongoEventsRepository` to avoid duplicate or unnecessary logging. (`src/infrastructure/mongo/mongo-events.repository.ts`, [src/infrastructure/mongo/mongo-events.repository.tsL21](diffhunk://#diff-4c1d6a121e53a40e67994f9405ac722824aaf0a99c62da80dc1c96b8abffa81fL21))