### PR TITLE
fix: add indexer and scheduler tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ coverage/
 # Environment files
 .env
 .env.docker
+
+# macOS
+.DS_Store

--- a/src/application/services/evm-indexer.service.spec.ts
+++ b/src/application/services/evm-indexer.service.spec.ts
@@ -1,37 +1,30 @@
 import { EVMIndexerService } from '@application/services/evm-indexer.service.js';
-import type { ChainConfig } from '@domain/entities/chain-config.entity.js';
-import { randomBytes } from 'crypto';
-import { BigNumber } from 'ethers';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EventsRepository } from '@domain/repositories/events.repository.interface.js';
+import type { EVMClient } from '@infrastructure/evm/evm-client.js';
+import {
+  buildChainConfig,
+  getRandomEvents,
+  randomInt,
+} from '@tests/fixtures.js';
+import { beforeEach, describe, expect, it, vi, type Mocked } from 'vitest';
 
-// TODO: builder?
-let chainConfig: ChainConfig;
-let evmClientMock: any;
-let eventsRepositoryMock: any;
-let evmIndexer: any;
+let evmClientMock: Mocked<EVMClient>;
+let eventsRepositoryMock: Mocked<EventsRepository>;
+let evmIndexer: EVMIndexerService;
 
 describe('EVMIndexerService', () => {
   beforeEach(() => {
-    chainConfig = {
-      chainId: randomInt().toString(),
-      chainName: 'testChain',
-      rpcUrl: 'https://example.com',
-      contractAddress: randomAddress(),
-      blockDelta: randomInt(),
-      initialBlockNumber: randomInt(),
-      intervalMs: randomInt(),
-    };
     evmClientMock = {
       fetchFeesCollectedEvents: vi.fn(),
       getLastBlockInChain: vi.fn(),
-    };
+    } as unknown as Mocked<EVMClient>;
     eventsRepositoryMock = {
       storeFeesCollectedEvents: vi.fn(),
       setFeesCollectedLastBlock: vi.fn(),
       getFeesCollectedLastBlock: vi.fn(),
-    };
+    } as unknown as Mocked<EventsRepository>;
     evmIndexer = new EVMIndexerService(
-      chainConfig,
+      buildChainConfig(),
       evmClientMock,
       eventsRepositoryMock,
     );
@@ -124,17 +117,3 @@ describe('EVMIndexerService', () => {
     });
   });
 });
-
-// Utility functions for test data generation
-const randomAddress = () => `0x${randomBytes(20).toString('hex')}`;
-const randomInt = () => Math.floor(Math.random() * 1000);
-const randomEvent = () => ({
-  token: randomAddress(),
-  integrator: randomAddress(),
-  integratorFee: BigNumber.from(randomInt()),
-  lifiFee: BigNumber.from(randomInt()),
-});
-const getRandomEvents = (maxEvents: number) =>
-  Array.from({
-    length: Math.floor(Math.random() * (maxEvents + 1)),
-  }).map(() => randomEvent());

--- a/src/application/services/evm-indexer.service.spec.ts
+++ b/src/application/services/evm-indexer.service.spec.ts
@@ -23,7 +23,7 @@ describe('EVMIndexerService', () => {
     };
     evmClientMock = {
       fetchFeesCollectedEvents: vi.fn(),
-      getLastBlockNumber: vi.fn(),
+      getLastBlockInChain: vi.fn(),
     };
     eventsRepositoryMock = {
       storeFeesCollectedEvents: vi.fn(),
@@ -84,20 +84,20 @@ describe('EVMIndexerService', () => {
     });
   });
 
-  describe('getLastBlockNumber', () => {
+  describe('getLastBlockInChain', () => {
     it('should return the last block number', async () => {
       const lastBlockNumber = randomInt();
-      evmClientMock.getLastBlockNumber.mockResolvedValue(lastBlockNumber);
-      const result = await evmIndexer.getLastBlockNumber();
+      evmClientMock.getLastBlockInChain.mockResolvedValue(lastBlockNumber);
+      const result = await evmIndexer.getLastBlockInChain();
       expect(result).toBe(lastBlockNumber);
-      expect(evmClientMock.getLastBlockNumber).toHaveBeenCalled();
+      expect(evmClientMock.getLastBlockInChain).toHaveBeenCalled();
     });
 
-    it('should propagate errors from getLastBlockNumber', async () => {
-      evmClientMock.getLastBlockNumber.mockRejectedValue(
+    it('should propagate errors from getLastBlockInChain', async () => {
+      evmClientMock.getLastBlockInChain.mockRejectedValue(
         new Error('Error message'),
       );
-      await expect(evmIndexer.getLastBlockNumber()).rejects.toThrow(
+      await expect(evmIndexer.getLastBlockInChain()).rejects.toThrow(
         'Error message',
       );
     });

--- a/src/application/services/evm-indexer.service.spec.ts
+++ b/src/application/services/evm-indexer.service.spec.ts
@@ -1,0 +1,140 @@
+import { EVMIndexerService } from '@application/services/evm-indexer.service.js';
+import type { ChainConfig } from '@domain/entities/chain-config.entity.js';
+import { randomBytes } from 'crypto';
+import { BigNumber } from 'ethers';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// TODO: builder?
+let chainConfig: ChainConfig;
+let evmClientMock: any;
+let eventsRepositoryMock: any;
+let evmIndexer: any;
+
+describe('EVMIndexerService', () => {
+  beforeEach(() => {
+    chainConfig = {
+      chainId: randomInt().toString(),
+      chainName: 'testChain',
+      rpcUrl: 'https://example.com',
+      contractAddress: randomAddress(),
+      blockDelta: randomInt(),
+      initialBlockNumber: randomInt(),
+      intervalMs: randomInt(),
+    };
+    evmClientMock = {
+      fetchFeesCollectedEvents: vi.fn(),
+      getLastBlockNumber: vi.fn(),
+    };
+    eventsRepositoryMock = {
+      storeFeesCollectedEvents: vi.fn(),
+      setFeesCollectedLastBlock: vi.fn(),
+      getFeesCollectedLastBlock: vi.fn(),
+    };
+    evmIndexer = new EVMIndexerService(
+      chainConfig,
+      evmClientMock,
+      eventsRepositoryMock,
+    );
+  });
+
+  describe('indexFeeCollectionEvents', () => {
+    it('should index fee collection events and set the last block', async () => {
+      const fromBlock = randomInt();
+      const toBlock = randomInt();
+      const events = getRandomEvents(5);
+      evmClientMock.fetchFeesCollectedEvents.mockResolvedValue(events);
+      await evmIndexer.indexFeeCollectionEvents(fromBlock, toBlock);
+      expect(evmClientMock.fetchFeesCollectedEvents).toHaveBeenCalledWith(
+        fromBlock,
+        toBlock,
+      );
+      expect(
+        eventsRepositoryMock.storeFeesCollectedEvents,
+      ).toHaveBeenCalledWith(events);
+      expect(
+        eventsRepositoryMock.setFeesCollectedLastBlock,
+      ).toHaveBeenCalledWith(toBlock);
+    });
+
+    it('should propagate errors from fetchFeesCollectedEvents', async () => {
+      evmClientMock.fetchFeesCollectedEvents.mockRejectedValue(
+        new Error('Error message'),
+      );
+      await expect(
+        evmIndexer.indexFeeCollectionEvents(randomInt(), randomInt()),
+      ).rejects.toThrow('Error message');
+    });
+
+    it('should propagate errors from storeFeesCollectedEvents', async () => {
+      eventsRepositoryMock.storeFeesCollectedEvents.mockRejectedValue(
+        new Error('Error message'),
+      );
+      await expect(
+        evmIndexer.indexFeeCollectionEvents(randomInt(), randomInt()),
+      ).rejects.toThrow('Error message');
+    });
+
+    it('should propagate errors from setFeesCollectedLastBlock', async () => {
+      eventsRepositoryMock.setFeesCollectedLastBlock.mockRejectedValue(
+        new Error('Error message'),
+      );
+      await expect(
+        evmIndexer.indexFeeCollectionEvents(randomInt(), randomInt()),
+      ).rejects.toThrow('Error message');
+    });
+  });
+
+  describe('getLastBlockNumber', () => {
+    it('should return the last block number', async () => {
+      const lastBlockNumber = randomInt();
+      evmClientMock.getLastBlockNumber.mockResolvedValue(lastBlockNumber);
+      const result = await evmIndexer.getLastBlockNumber();
+      expect(result).toBe(lastBlockNumber);
+      expect(evmClientMock.getLastBlockNumber).toHaveBeenCalled();
+    });
+
+    it('should propagate errors from getLastBlockNumber', async () => {
+      evmClientMock.getLastBlockNumber.mockRejectedValue(
+        new Error('Error message'),
+      );
+      await expect(evmIndexer.getLastBlockNumber()).rejects.toThrow(
+        'Error message',
+      );
+    });
+  });
+
+  describe('getLastIndexedBlockNumber', () => {
+    it('should return the last indexed block number', async () => {
+      const lastIndexedBlockNumber = randomInt();
+      eventsRepositoryMock.getFeesCollectedLastBlock.mockResolvedValue(
+        lastIndexedBlockNumber,
+      );
+      const result = await evmIndexer.getLastIndexedBlockNumber();
+      expect(result).toBe(lastIndexedBlockNumber);
+      expect(eventsRepositoryMock.getFeesCollectedLastBlock).toHaveBeenCalled();
+    });
+
+    it('should propagate errors from getFeesCollectedLastBlock', async () => {
+      eventsRepositoryMock.getFeesCollectedLastBlock.mockRejectedValue(
+        new Error('Error message'),
+      );
+      await expect(evmIndexer.getLastIndexedBlockNumber()).rejects.toThrow(
+        'Error message',
+      );
+    });
+  });
+});
+
+// Utility functions for test data generation
+const randomAddress = () => `0x${randomBytes(20).toString('hex')}`;
+const randomInt = () => Math.floor(Math.random() * 1000);
+const randomEvent = () => ({
+  token: randomAddress(),
+  integrator: randomAddress(),
+  integratorFee: BigNumber.from(randomInt()),
+  lifiFee: BigNumber.from(randomInt()),
+});
+const getRandomEvents = (maxEvents: number) =>
+  Array.from({
+    length: Math.floor(Math.random() * (maxEvents + 1)),
+  }).map(() => randomEvent());

--- a/src/application/services/evm-indexer.service.ts
+++ b/src/application/services/evm-indexer.service.ts
@@ -10,16 +10,12 @@ export class EVMIndexerService {
     private eventsRepository: EventsRepository,
   ) {}
 
-  // TODO: add tests
-
   async indexFeeCollectionEvents(
     fromBlock: number,
     toBlock: number,
   ): Promise<void> {
     const { chainName } = this.chainConfig;
-    logger.info(
-      `[${chainName}] Indexing block ${fromBlock} to block ${toBlock}`,
-    );
+    logger.info(`[${chainName}] Indexing block range ${fromBlock}-${toBlock}`);
     const events = await this.evmClient.fetchFeesCollectedEvents(
       fromBlock,
       toBlock,

--- a/src/application/services/evm-indexer.service.ts
+++ b/src/application/services/evm-indexer.service.ts
@@ -29,8 +29,8 @@ export class EVMIndexerService {
     logger.info(`[${chainName}] ${events.length} event(s) indexed`);
   }
 
-  async getLastBlockNumber(): Promise<number> {
-    return this.evmClient.getLastBlockNumber();
+  async getLastBlockInChain(): Promise<number> {
+    return this.evmClient.getLastBlockInChain();
   }
 
   async getLastIndexedBlockNumber(): Promise<number | null> {

--- a/src/container.ts
+++ b/src/container.ts
@@ -28,12 +28,12 @@ const chainConfigs: ChainConfig[] = [
   },
 ];
 
-export async function bootstrap() {
+export async function bootstrap(): Promise<void> {
   db.initializeDatabase({ uri: process.env.MONGO_URI! });
   await Promise.all(chainConfigs.map((config) => _bootstrapChain(config)));
 }
 
-async function _bootstrapChain(chainConfig: ChainConfig) {
+async function _bootstrapChain(chainConfig: ChainConfig): Promise<void> {
   const { chainName } = chainConfig;
   const feesCollectedLastBlockModel = getFeesCollectedLastBlockModel(chainName);
   const feesCollectedEventModel = getFeesCollectedEventModel(chainName);

--- a/src/domain/repositories/evm-client.interface.ts
+++ b/src/domain/repositories/evm-client.interface.ts
@@ -8,5 +8,5 @@ export interface EVMClient {
     toBlock: BlockTag,
   ): Promise<ParsedFeesCollectedEvent[]>;
 
-  getLastBlockNumber(): Promise<number>;
+  getLastBlockInChain(): Promise<number>;
 }

--- a/src/infrastructure/evm/evm-client.spec.ts
+++ b/src/infrastructure/evm/evm-client.spec.ts
@@ -1,6 +1,6 @@
 import type { ChainConfig } from '@domain/entities/chain-config.entity.js';
 import { EVMClient } from '@infrastructure/evm/evm-client.js';
-import { randomBytes } from 'crypto';
+import { randomAddress, randomInt } from '@tests/fixtures.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let contractMock: any;
@@ -108,7 +108,3 @@ describe('EVMClient', () => {
     });
   });
 });
-
-// Utility functions for test data generation
-const randomAddress = () => `0x${randomBytes(20).toString('hex')}`;
-const randomInt = () => Math.floor(Math.random() * 1000);

--- a/src/infrastructure/evm/evm-client.spec.ts
+++ b/src/infrastructure/evm/evm-client.spec.ts
@@ -1,7 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { EVMClient } from './evm-client';
-import { type ChainConfig } from '../../domain/entities/chain-config.entity.js';
+import type { ChainConfig } from '@domain/entities/chain-config.entity.js';
+import { EVMClient } from '@infrastructure/evm/evm-client.js';
 import { randomBytes } from 'crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let contractMock: any;
 let providerMock: any;

--- a/src/infrastructure/evm/evm-client.spec.ts
+++ b/src/infrastructure/evm/evm-client.spec.ts
@@ -89,12 +89,12 @@ describe('EVMClient', () => {
     });
   });
 
-  describe('getLastBlockNumber', () => {
+  describe('getLastBlockInChain', () => {
     it('should return block number', async () => {
       const blockNumber = randomInt();
       providerMock.getBlock.mockResolvedValue({ number: blockNumber });
 
-      const result = await client.getLastBlockNumber();
+      const result = await client.getLastBlockInChain();
 
       expect(result).toBe(blockNumber);
       expect(providerMock.getBlock).toHaveBeenCalledWith('latest');
@@ -102,7 +102,7 @@ describe('EVMClient', () => {
 
     it('should throw if block is null', async () => {
       providerMock.getBlock.mockResolvedValue(null);
-      await expect(client.getLastBlockNumber()).rejects.toThrow(
+      await expect(client.getLastBlockInChain()).rejects.toThrow(
         'Failed to fetch the latest block number',
       );
     });

--- a/src/infrastructure/evm/evm-client.ts
+++ b/src/infrastructure/evm/evm-client.ts
@@ -38,7 +38,7 @@ export class EVMClient implements EVMClientInterface {
     });
   }
 
-  async getLastBlockNumber(): Promise<number> {
+  async getLastBlockInChain(): Promise<number> {
     const block = await this.provider.getBlock('latest');
     if (!block) {
       throw new Error('Failed to fetch the latest block number');

--- a/src/infrastructure/jobs/evm-indexer.scheduler.spec.ts
+++ b/src/infrastructure/jobs/evm-indexer.scheduler.spec.ts
@@ -1,0 +1,81 @@
+import type { ChainConfig } from '@domain/entities/chain-config.entity.js';
+import { EVMScheduler } from '@infrastructure/jobs/evm-indexer.scheduler.js';
+import { randomBytes } from 'crypto';
+import { BigNumber } from 'ethers';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let indexerService: any;
+let scheduler: EVMScheduler;
+let chainConfig: ChainConfig;
+
+describe('EVMScheduler', () => {
+  beforeEach(() => {
+    indexerService = {
+      getLastBlockNumber: vi.fn(),
+      getLastIndexedBlockNumber: vi.fn(),
+      indexFeeCollectionEvents: vi.fn(),
+    };
+    vi.clearAllMocks();
+  });
+
+  it('should index from the configured initialBlockNumber to the chain lastBlockNumber if (lastIndexedBlockNumber < initialBlockNumber)', async () => {
+    indexerService.getLastBlockNumber.mockResolvedValue(1_000);
+    indexerService.getLastIndexedBlockNumber.mockResolvedValue(100);
+    const chainConfig = {
+      chainId: randomInt().toString(),
+      chainName: 'testChain',
+      rpcUrl: 'https://example.com',
+      contractAddress: randomAddress(),
+      blockDelta: 10,
+      initialBlockNumber: 200,
+      intervalMs: 1000,
+    };
+    scheduler = new EVMScheduler(indexerService, chainConfig);
+
+    const nextBlock = await scheduler.indexJob();
+
+    expect(nextBlock).toBe(210);
+    expect(indexerService.indexFeeCollectionEvents).toHaveBeenCalledWith(
+      200,
+      209,
+    );
+  });
+
+  it('should index from the lastIndexedBlockNumber to the chain lastBlockNumber if (lastIndexedBlockNumber >= initialBlockNumber)', async () => {
+    indexerService.getLastBlockNumber.mockResolvedValue(1_000);
+    indexerService.getLastIndexedBlockNumber.mockResolvedValue(299);
+    const chainConfig = {
+      chainId: randomInt().toString(),
+      chainName: 'testChain',
+      rpcUrl: 'https://example.com',
+      contractAddress: randomAddress(),
+      blockDelta: 10,
+      initialBlockNumber: 200,
+      intervalMs: 1000,
+    };
+    scheduler = new EVMScheduler(indexerService, chainConfig);
+
+    const nextBlock = await scheduler.indexJob();
+
+    expect(nextBlock).toBe(310);
+    expect(indexerService.indexFeeCollectionEvents).toHaveBeenCalledWith(
+      300,
+      309,
+    );
+  });
+});
+
+// TODO: extract this
+// Utility functions for test data generation
+const randomAddress = () => `0x${randomBytes(20).toString('hex')}`;
+const randomInt = () => Math.floor(Math.random() * 1000);
+const randomEvent = () => ({
+  token: randomAddress(),
+  integrator: randomAddress(),
+  integratorFee: BigNumber.from(randomInt()),
+  lifiFee: BigNumber.from(randomInt()),
+});
+const getRandomEvents = (maxEvents: number) =>
+  Array.from({
+    length: Math.floor(Math.random() * (maxEvents + 1)),
+  }).map(() => randomEvent());

--- a/src/infrastructure/jobs/evm-indexer.scheduler.ts
+++ b/src/infrastructure/jobs/evm-indexer.scheduler.ts
@@ -1,30 +1,66 @@
 import { type EVMIndexerService } from '@application/services/evm-indexer.service.js';
 import type { ChainConfig } from '@domain/entities/chain-config.entity.js';
 
+type BlockRange = { startBlock: number; endBlock: number };
+
 export class EVMScheduler {
-  private latestBlock: number;
+  private nextBlock: number;
 
   constructor(
     private indexerService: EVMIndexerService,
     private chainConfig: ChainConfig,
   ) {
-    this.latestBlock = chainConfig.initialBlockNumber - 1;
+    this.nextBlock = chainConfig.initialBlockNumber;
   }
 
+  /**
+   * Starts the indexing job.
+   */
   async start(): Promise<void> {
-    await this._indexJob();
-    setInterval(() => this._indexJob(), this.chainConfig.intervalMs);
+    await this.indexJob();
+    setInterval(() => this.indexJob(), this.chainConfig.intervalMs);
   }
 
-  private async _indexJob() {
-    const lastBlock = await this.indexerService.getLastBlockNumber();
+  /**
+   * Indexes the fee collection events for the current block range.
+   * Returns the next block number to be processed.
+   * Note: This method is public for testing purposes.
+   */
+  public async indexJob(): Promise<number> {
+    const latestBlockInChain = await this.indexerService.getLastBlockNumber();
+    const { startBlock, endBlock } =
+      await this._getBlockRange(latestBlockInChain);
+    await this.indexerService.indexFeeCollectionEvents(startBlock, endBlock);
+    this.nextBlock = Math.min(endBlock + 1, latestBlockInChain);
+    return this.nextBlock;
+  }
+
+  /**
+   * Computes the next block range to index.
+   *
+   * The range starts at:
+   * - the {@link ChainConfig.initialBlockNumber}, if no blocks have been indexed yet, or
+   *   if the {@link ChainConfig.initialBlockNumber} is greater than the last indexed block.
+   * - otherwise, the block immediately after the last indexed block.
+   *
+   * The range ends at `startBlock + {@link ChainConfig.blockDelta}`, unless that would exceed the
+   * {@link latestBlockInChain}, in which case it is capped at {@link latestBlockInChain}.
+   *
+   * @param latestBlockInChain The latest block number currently available in the chain.
+   * @returns An inclusive {@link BlockRange} to be indexed.
+   */
+  private async _getBlockRange(
+    latestBlockInChain: number,
+  ): Promise<BlockRange> {
     const lastIndexed = await this.indexerService.getLastIndexedBlockNumber();
-    const fromBlock = (lastIndexed ?? this.latestBlock) + 1;
-    const toBlock = Math.min(
-      fromBlock + this.chainConfig.blockDelta - 1,
-      lastBlock,
+    const startBlock =
+      lastIndexed && lastIndexed >= this.chainConfig.initialBlockNumber
+        ? lastIndexed + 1
+        : this.nextBlock;
+    const endBlock = Math.min(
+      startBlock + this.chainConfig.blockDelta - 1,
+      latestBlockInChain,
     );
-    await this.indexerService.indexFeeCollectionEvents(fromBlock, toBlock);
-    this.latestBlock = Math.min(toBlock + 1, lastBlock);
+    return { startBlock, endBlock };
   }
 }

--- a/src/infrastructure/jobs/evm-indexer.scheduler.ts
+++ b/src/infrastructure/jobs/evm-indexer.scheduler.ts
@@ -27,7 +27,7 @@ export class EVMScheduler {
    * Note: This method is public for testing purposes.
    */
   public async indexJob(): Promise<number> {
-    const latestBlockInChain = await this.indexerService.getLastBlockNumber();
+    const latestBlockInChain = await this.indexerService.getLastBlockInChain();
     const { startBlock, endBlock } =
       await this._getBlockRange(latestBlockInChain);
     await this.indexerService.indexFeeCollectionEvents(startBlock, endBlock);

--- a/src/infrastructure/mongo/mappers/parsed-fees-collected-event.mapper.spec.ts
+++ b/src/infrastructure/mongo/mappers/parsed-fees-collected-event.mapper.spec.ts
@@ -1,0 +1,34 @@
+import { ParsedFeesCollectedEventMapper } from '@infrastructure/mongo/mappers/parsed-fees-collected-event.mapper.js';
+import type { ParsedFeesCollectedEvent } from '@infrastructure/mongo/models/parsed-fees-collected-event.model.js';
+import { buildEvent, randomAddress, randomInt } from '@tests/fixtures.js';
+import { BigNumber } from 'ethers';
+import { describe, expect, it } from 'vitest';
+
+describe('ParsedFeesCollectedEventMapper', () => {
+  it('toPersistence should convert BigNumber fields to strings', () => {
+    const event = buildEvent();
+    const result = ParsedFeesCollectedEventMapper.toPersistence(event);
+    expect(result).toEqual({
+      token: event.token,
+      integrator: event.integrator,
+      integratorFee: event.integratorFee.toString(),
+      lifiFee: event.lifiFee.toString(),
+    });
+  });
+
+  it('toDomain should convert string fields to BigNumber', () => {
+    const doc: InstanceType<typeof ParsedFeesCollectedEvent> = {
+      token: randomAddress(),
+      integrator: randomAddress(),
+      integratorFee: randomInt().toString(),
+      lifiFee: randomInt().toString(),
+    };
+    const result = ParsedFeesCollectedEventMapper.toDomain(doc);
+    expect(result).toEqual({
+      token: doc.token,
+      integrator: doc.integrator,
+      integratorFee: BigNumber.from(doc.integratorFee),
+      lifiFee: BigNumber.from(doc.lifiFee),
+    });
+  });
+});

--- a/src/infrastructure/mongo/mappers/parsed-fees-collected-event.mapper.ts
+++ b/src/infrastructure/mongo/mappers/parsed-fees-collected-event.mapper.ts
@@ -1,11 +1,13 @@
 import type { ParsedFeesCollectedEvent } from '@domain/entities/parsed-fees-collected-event.entity.js';
-import { ParsedFeesCollectedEvent as ParsedFeesCollectedEventModel } from '@infrastructure/mongo/models/parsed-fees-collected-event.model.js';
+import type { ParsedFeesCollectedEvent as ParsedFeesCollectedEventModel } from '@infrastructure/mongo/models/parsed-fees-collected-event.model.js';
 import { BigNumber } from 'ethers';
 
 // TODO: add tests
 
 export class ParsedFeesCollectedEventMapper {
-  static toPersistence(event: ParsedFeesCollectedEvent) {
+  static toPersistence(
+    event: ParsedFeesCollectedEvent,
+  ): ParsedFeesCollectedEventModel {
     return {
       token: event.token,
       integrator: event.integrator,

--- a/src/infrastructure/mongo/mappers/parsed-fees-collected-event.mapper.ts
+++ b/src/infrastructure/mongo/mappers/parsed-fees-collected-event.mapper.ts
@@ -2,6 +2,8 @@ import type { ParsedFeesCollectedEvent } from '@domain/entities/parsed-fees-coll
 import { ParsedFeesCollectedEvent as ParsedFeesCollectedEventModel } from '@infrastructure/mongo/models/parsed-fees-collected-event.model.js';
 import { BigNumber } from 'ethers';
 
+// TODO: add tests
+
 export class ParsedFeesCollectedEventMapper {
   static toPersistence(event: ParsedFeesCollectedEvent) {
     return {

--- a/src/infrastructure/mongo/mongo-events.repository.spec.ts
+++ b/src/infrastructure/mongo/mongo-events.repository.spec.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MongoEventsRepository } from './mongo-events.repository';
-import { ParsedFeesCollectedEventMapper } from './mappers/parsed-fees-collected-event.mapper';
+import { ParsedFeesCollectedEventMapper } from '@infrastructure/mongo/mappers/parsed-fees-collected-event.mapper.js';
+import { MongoEventsRepository } from '@infrastructure/mongo/mongo-events.repository.js';
 import { randomBytes } from 'crypto';
+import { BigNumber } from 'ethers';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let feesCollectedEventsModelMock: any;
 let feesCollectedLastBlockModelMock: any;
@@ -98,8 +99,8 @@ const randomInt = () => Math.floor(Math.random() * 1000);
 const randomEvent = () => ({
   token: randomAddress(),
   integrator: randomAddress(),
-  integratorFee: randomInt(),
-  lifiFee: randomInt(),
+  integratorFee: BigNumber.from(randomInt()),
+  lifiFee: BigNumber.from(randomInt()),
 });
 const getRandomEvents = (maxEvents: number) =>
   Array.from({

--- a/src/infrastructure/mongo/mongo-events.repository.spec.ts
+++ b/src/infrastructure/mongo/mongo-events.repository.spec.ts
@@ -1,21 +1,24 @@
 import { ParsedFeesCollectedEventMapper } from '@infrastructure/mongo/mappers/parsed-fees-collected-event.mapper.js';
+import type { FeesCollectedLastBlockModel } from '@infrastructure/mongo/models/fees-collected-last-block.model.js';
+import type { FeesCollectedEventModel } from '@infrastructure/mongo/models/parsed-fees-collected-event.model.js';
 import { MongoEventsRepository } from '@infrastructure/mongo/mongo-events.repository.js';
-import { randomBytes } from 'crypto';
-import { BigNumber } from 'ethers';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRandomEvents, randomInt } from '@tests/fixtures.js';
+import { beforeEach, describe, expect, it, vi, type Mocked } from 'vitest';
 
-let feesCollectedEventsModelMock: any;
-let feesCollectedLastBlockModelMock: any;
+let feesCollectedEventsModelMock: Mocked<FeesCollectedEventModel>;
+let feesCollectedLastBlockModelMock: Mocked<FeesCollectedLastBlockModel>;
 let repository: MongoEventsRepository;
 
 describe('MongoEventsRepository', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    feesCollectedEventsModelMock = { insertMany: vi.fn() };
+    feesCollectedEventsModelMock = {
+      insertMany: vi.fn(),
+    } as unknown as Mocked<FeesCollectedEventModel>;
     feesCollectedLastBlockModelMock = {
       updateOne: vi.fn(),
       findOne: vi.fn(),
-    };
+    } as unknown as Mocked<FeesCollectedLastBlockModel>;
     repository = new MongoEventsRepository(
       feesCollectedLastBlockModelMock,
       feesCollectedEventsModelMock,
@@ -92,17 +95,3 @@ describe('MongoEventsRepository', () => {
     });
   });
 });
-
-// Utility functions for test data generation
-const randomAddress = () => `0x${randomBytes(20).toString('hex')}`;
-const randomInt = () => Math.floor(Math.random() * 1000);
-const randomEvent = () => ({
-  token: randomAddress(),
-  integrator: randomAddress(),
-  integratorFee: BigNumber.from(randomInt()),
-  lifiFee: BigNumber.from(randomInt()),
-});
-const getRandomEvents = (maxEvents: number) =>
-  Array.from({
-    length: Math.floor(Math.random() * (maxEvents + 1)),
-  }).map(() => randomEvent());

--- a/src/tests/fixtures.ts
+++ b/src/tests/fixtures.ts
@@ -1,0 +1,37 @@
+import type { ChainConfig } from '@domain/entities/chain-config.entity.js';
+import { randomBytes } from 'crypto';
+import { BigNumber } from 'ethers';
+
+export const randomAddress = (): string =>
+  `0x${randomBytes(20).toString('hex')}`;
+
+export const randomInt = (): number => Math.floor(Math.random() * 1000);
+
+export const getRandomEvents = (
+  maxEvents: number,
+): Array<ReturnType<typeof buildEvent>> =>
+  Array.from({
+    length: Math.floor(Math.random() * (maxEvents + 1)),
+  }).map(() => buildEvent());
+
+export const buildEvent = (): {
+  token: string;
+  integrator: string;
+  integratorFee: BigNumber;
+  lifiFee: BigNumber;
+} => ({
+  token: randomAddress(),
+  integrator: randomAddress(),
+  integratorFee: BigNumber.from(randomInt()),
+  lifiFee: BigNumber.from(randomInt()),
+});
+
+export const buildChainConfig = (): ChainConfig => ({
+  chainId: randomInt().toString(),
+  chainName: 'testChain',
+  rpcUrl: 'https://example.com',
+  contractAddress: randomAddress(),
+  blockDelta: randomInt(),
+  initialBlockNumber: randomInt(),
+  intervalMs: randomInt(),
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,5 @@
     "target": "ES2020",
     "verbatimModuleSyntax": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
This pull request introduces comprehensive unit tests for core EVM indexing and scheduling services, improves code consistency, and refines block range handling for event indexing. These changes ensure more reliable and predictable behavior of the EVM indexer and its scheduler, and improve test coverage across the infrastructure layer.

**New and Improved Tests**
* Added thorough unit tests for `EVMIndexerService`, covering event indexing, error propagation, and block retrieval methods. (`src/application/services/evm-indexer.service.spec.ts`)
* Added tests for `EVMScheduler`, verifying correct block range selection and event indexing logic for initial and subsequent runs. (`src/infrastructure/jobs/evm-indexer.scheduler.spec.ts`)
* Improved test imports and mocks for MongoDB event repository and EVM client, ensuring consistency in test data generation and usage. (`src/infrastructure/mongo/mongo-events.repository.spec.ts`, `src/infrastructure/evm/evm-client.spec.ts`) [[1]](diffhunk://#diff-5d91adcb516fb324e15015a078a78fbedd7d2be0bc8d33b57457d20828490ba3L1-R5) [[2]](diffhunk://#diff-e1729aba60ce1bad7cc9c0ae86b133e798bbec630f96cfda1f8932c0fc7acaecL1-R4)

**Block Range Calculation and Indexing Logic**
* Refactored `EVMScheduler` to use a `nextBlock` property and a new `_getBlockRange` method, ensuring correct and predictable block range selection for event indexing. The indexing job now starts from the configured initial block number and advances appropriately. (`src/infrastructure/jobs/evm-indexer.scheduler.ts`)
* Improved logging in `EVMIndexerService` to clarify block range being indexed. (`src/application/services/evm-indexer.service.ts`)

**Test Data Consistency**
* Updated test event generation to use `BigNumber` for fee amounts, matching production code expectations. (`src/infrastructure/mongo/mongo-events.repository.spec.ts`)

**Code Quality**
* Added TODOs for missing tests in mappers and services, highlighting areas for future improvement. (`src/infrastructure/mongo/mappers/parsed-fees-collected-event.mapper.ts`)